### PR TITLE
Fix(CI/CD): Resolve deployment failures and improve pipeline logic

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -107,9 +107,6 @@ jobs:
     - name: Install dependencies
       run: composer install --no-dev --optimize-autoloader
 
-    - name: Run production tests
-      run: composer test
-
     - name: Deploy to Production
       run: php scripts/deploy/deploy.php production
       env:


### PR DESCRIPTION
This commit resolves two issues in the production deployment workflow:

- Removes the redundant "Run production tests" step. This step was failing as it ran after dev dependencies (like PHPUnit) were removed. The `test` job already guarantees code quality before this stage.
- Corrects the syntax for making the Slack notification step optional. The step now only runs if the `SLACK_WEBHOOK_URL` secret is defined, preventing errors for users without this configuration.